### PR TITLE
Auto discover adaptor

### DIFF
--- a/src/Adaptors/AutoDiscover.php
+++ b/src/Adaptors/AutoDiscover.php
@@ -17,11 +17,24 @@
 
 namespace Okta\JwtVerifier\Adaptors;
 
-use Okta\JwtVerifier\Jwt;
-
-interface Adaptor
+class AutoDiscover
 {
-    public function getKeys($jku);
-    public function decode($jwt, $keys): Jwt;
-    public static function isPackageAvailable();
+    private $adaptors = [
+        SpomkyLabsJose::class,
+        FirebasePhpJwt::class
+    ];
+
+    public function __construct()
+    {
+        foreach($this->adaptors as $adaptor) {
+            if($adaptor::isPackageAvailable()) {
+                return new $adaptor();
+            }
+        }
+
+        throw new \Exception(
+            'Could not discover JWT Library, 
+            Please make sure one is included and the Adaptor is used'
+        );
+    }
 }

--- a/src/Adaptors/AutoDiscover.php
+++ b/src/Adaptors/AutoDiscover.php
@@ -19,21 +19,21 @@ namespace Okta\JwtVerifier\Adaptors;
 
 class AutoDiscover
 {
-    private $adaptors = [
+    private static $adaptors = [
         SpomkyLabsJose::class,
         FirebasePhpJwt::class
     ];
 
-    public function __construct()
+    public static function getAdaptor()
     {
-        foreach($this->adaptors as $adaptor) {
+        foreach(self::$adaptors as $adaptor) {
             if($adaptor::isPackageAvailable()) {
                 return new $adaptor();
             }
         }
 
         throw new \Exception(
-            'Could not discover JWT Library, 
+            'Could not discover JWT Library,
             Please make sure one is included and the Adaptor is used'
         );
     }

--- a/src/Adaptors/FirebasePhpJwt.php
+++ b/src/Adaptors/FirebasePhpJwt.php
@@ -44,6 +44,11 @@ class FirebasePhpJwt implements Adaptor
         return (new Jwt($jwt, $decoded));
     }
 
+    public static function isPackageAvailable()
+    {
+        return class_exists(\Firebase\JWT\JWT::class);
+    }
+
     /**
      * Parse a set of JWK keys
      * @param $source

--- a/src/Adaptors/SpomkyLabsJose.php
+++ b/src/Adaptors/SpomkyLabsJose.php
@@ -39,4 +39,11 @@ class SpomkyLabsJose implements Adaptor
 
         return (new Jwt($jwt, $decoded->getPayload()));
     }
+
+    public static function isPackageAvailable()
+    {
+        return
+            class_exists(\Jose\Factory\JWKFactory::class) &&
+            class_exists(Loader::class);
+    }
 }

--- a/src/JwtVerifier.php
+++ b/src/JwtVerifier.php
@@ -47,7 +47,7 @@ class JwtVerifier
     ) {
         $this->issuer = $issuer;
         $this->discovery = $discovery ?: new Oauth;
-        $this->adaptor = $adaptor ?: new AutoDiscover;
+        $this->adaptor = $adaptor ?: AutoDiscover::getAdaptor();
         $request = $request ?: new Request;
         $this->metaData = json_decode($request->setUrl($this->issuer.$this->discovery->getWellKnown())->get()
             ->getBody());

--- a/src/JwtVerifier.php
+++ b/src/JwtVerifier.php
@@ -23,7 +23,9 @@ use Http\Discovery\HttpClientDiscovery;
 use Http\Discovery\MessageFactoryDiscovery;
 use Http\Discovery\UriFactoryDiscovery;
 use Okta\JwtVerifier\Adaptors\Adaptor;
+use Okta\JwtVerifier\Adaptors\AutoDiscover;
 use Okta\JwtVerifier\Discovery\DiscoveryMethod;
+use Okta\JwtVerifier\Discovery\Oauth;
 
 class JwtVerifier
 {
@@ -39,13 +41,13 @@ class JwtVerifier
 
     public function __construct(
         string $issuer,
-        DiscoveryMethod $discovery,
-        Adaptor $adaptor,
+        DiscoveryMethod $discovery = null,
+        Adaptor $adaptor = null,
         Request $request = null
     ) {
         $this->issuer = $issuer;
-        $this->discovery = $discovery;
-        $this->adaptor = $adaptor;
+        $this->discovery = $discovery ?: new Oauth;
+        $this->adaptor = $adaptor ?: new AutoDiscover;
         $request = $request ?: new Request;
         $this->metaData = json_decode($request->setUrl($this->issuer.$this->discovery->getWellKnown())->get()
             ->getBody());

--- a/src/JwtVerifierBuilder.php
+++ b/src/JwtVerifierBuilder.php
@@ -30,7 +30,6 @@ class JwtVerifierBuilder
 
     public function __construct(Request $request = null)
     {
-        $this->setDiscovery(new Oauth());
         $this->request = $request;
     }
 
@@ -60,12 +59,20 @@ class JwtVerifierBuilder
         return $this;
     }
 
+    /**
+     * Set the Adaptor class. This class should be an interface of Adaptor.
+     *
+     * @param Adaptor $adaptor The adaptor of the JWT library you are using.
+     * @return JwtVerifierBuilder
+     */
     public function setAdaptor(Adaptor $adaptor): self
     {
         $this->adaptor = $adaptor;
 
         return $this;
     }
+
+    
 
     /**
      * Build and return the JwtVerifier.


### PR DESCRIPTION
Resolves #6 

This auto-discovers supported jwt libraries.

By doing this, we remove the requirement for a user to add 

```
->setAdaptor(new \Okta\JwtVerifier\Adaptors\*)
```