### PR TITLE
Remove unneeded symfony/yaml dep

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
     },
     "require": {
         "php": "^7.0",
-        "symfony/yaml": "^3.2|^4.0",
         "nesbot/carbon": "^1.22",
         "psr/http-message": "^1.0",
         "php-http/client-common": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b263f3c8df19ea45b36851db6d5d186e",
+    "content-hash": "3b689e0ab4309c75c0a7bcd5bb9a9afc",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -742,61 +742,6 @@
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
             "time": "2017-06-24T16:45:30+00:00"
-        },
-        {
-            "name": "symfony/yaml",
-            "version": "v3.3.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "1f93a8d19b8241617f5074a123e282575b821df8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/1f93a8d19b8241617f5074a123e282575b821df8",
-                "reference": "1f93a8d19b8241617f5074a123e282575b821df8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.9"
-            },
-            "require-dev": {
-                "symfony/console": "~2.8|~3.0"
-            },
-            "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Yaml Component",
-            "homepage": "https://symfony.com",
-            "time": "2017-06-15T12:58:50+00:00"
         }
     ],
     "packages-dev": [
@@ -2007,6 +1952,7 @@
                 "mock",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2017-06-30T08:15:21+00:00"
         },
         {
@@ -2806,6 +2752,7 @@
                 "jwa",
                 "jwt"
             ],
+            "abandoned": "web-token/jwt-framework",
             "time": "2017-02-06T18:22:51+00:00"
         },
         {


### PR DESCRIPTION
Hey!  Hopefully this is a quick one: This PR removes the `symfony/yaml` dependency, which is unused in this package but causes lots of conflicts with some legacy systems I'm currently trying to integrate Okta with.
