### PR TITLE
Also allow Carbon 2 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": "^7.0",
-        "nesbot/carbon": "^1.22",
+        "nesbot/carbon": "^1.22 || ^2.0",
         "psr/http-message": "^1.0",
         "php-http/client-common": "^1.1",
         "php-http/httplug": "^1.1",


### PR DESCRIPTION
Since there is no breaking change for the functionality used by the okta-jwt-verifier-php package in the Carbon package we can allow both the current version constraint as well as ^2.0. 

This is an obvious fix.

Fixes #35 & #26 