### PR TITLE
Types and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 .vscode
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM php:7.2-cli-stretch
+
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+
+COPY . /app
+WORKDIR /app
+
+RUN composer install
+

--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ If you run into problems using the SDK, you can
 The above are the basic steps for verifying an access token locally. The steps are not tied directly to a framework so
 you could plug in the `okta/okta-jwt` into the framework of your choice.
 
+## Development
+
+The repository contains a `Dockerfile` you can use to run the test suite locally:
+
+```bash
+# build the docker
+docker build -t okta-jwt-verifier .
+# run the tests
+docker run --rm --volume "$PWD":/app okta-jwt-verifier vendor/bin/phpunit
+```
 
 [devforum]: https://devforum.okta.com/
 [lang-landing]: https://developer.okta.com/code/php/

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     },
     "require": {
         "php": "^7.2",
+        "ext-json": "*",
         "nesbot/carbon": "^2.0",
         "psr/http-message": "^1.0",
         "php-http/client-common": "^2.3",

--- a/src/Adaptors/Adaptor.php
+++ b/src/Adaptors/Adaptor.php
@@ -23,5 +23,5 @@ interface Adaptor
 {
     public function getKeys($jku);
     public function decode($jwt, $keys): Jwt;
-    public static function isPackageAvailable();
+    public static function isPackageAvailable(): bool;
 }

--- a/src/Adaptors/AutoDiscover.php
+++ b/src/Adaptors/AutoDiscover.php
@@ -17,6 +17,8 @@
 
 namespace Okta\JwtVerifier\Adaptors;
 
+use RuntimeException;
+
 class AutoDiscover
 {
     private static $adaptors = [
@@ -25,13 +27,13 @@ class AutoDiscover
 
     public static function getAdaptor()
     {
-        foreach(self::$adaptors as $adaptor) {
-            if($adaptor::isPackageAvailable()) {
+        foreach (self::$adaptors as $adaptor) {
+            if ($adaptor instanceof Adaptor && $adaptor::isPackageAvailable()) {
                 return new $adaptor();
             }
         }
 
-        throw new \Exception(
+        throw new RuntimeException(
             'Could not discover JWT Library,
             Please make sure one is included and the Adaptor is used'
         );

--- a/src/Discovery/DefaultDiscoveryMethod.php
+++ b/src/Discovery/DefaultDiscoveryMethod.php
@@ -17,7 +17,17 @@
 
 namespace Okta\JwtVerifier\Discovery;
 
-interface DiscoveryMethodInterface
+class DefaultDiscoveryMethod implements DiscoveryMethod
 {
-    public function getWellKnown(): string;
+    protected $wellKnown;
+
+    public function __construct(string $wellKnown)
+    {
+        $this->wellKnown = $wellKnown;
+    }
+
+    public function getWellKnown(): string
+    {
+        return $this->wellKnown;
+    }
 }

--- a/src/Discovery/DiscoveryMethod.php
+++ b/src/Discovery/DiscoveryMethod.php
@@ -17,18 +17,13 @@
 
 namespace Okta\JwtVerifier\Discovery;
 
-
-class DiscoveryMethod implements DiscoveryMethodInterface
+interface DiscoveryMethod
 {
-    protected $wellKnown;
-
-    public function __construct(string $wellKnown)
-    {
-        $this->wellKnown = $wellKnown;
-    }
-
-    public function getWellKnown(): string
-    {
-        return $this->wellKnown;
-    }
+    /**
+     * Get the defined well-known URI.  This is the URI
+     * that is concatenated to the issuer URL.
+     *
+     * @return string
+     */
+    public function getWellKnown(): string;
 }

--- a/src/Discovery/DiscoveryMethodInterface.php
+++ b/src/Discovery/DiscoveryMethodInterface.php
@@ -17,18 +17,7 @@
 
 namespace Okta\JwtVerifier\Discovery;
 
-
-class DiscoveryMethod implements DiscoveryMethodInterface
+interface DiscoveryMethodInterface
 {
-    protected $wellKnown;
-
-    public function __construct(string $wellKnown)
-    {
-        $this->wellKnown = $wellKnown;
-    }
-
-    public function getWellKnown(): string
-    {
-        return $this->wellKnown;
-    }
+    public function getWellKnown(): string;
 }

--- a/src/Discovery/Oauth.php
+++ b/src/Discovery/Oauth.php
@@ -17,22 +17,16 @@
 
 namespace Okta\JwtVerifier\Discovery;
 
-use Okta\JwtVerifier\Discovery\DiscoveryMethod as Discovery;
-
-class Oauth extends Discovery
+class Oauth implements DiscoveryMethodInterface
 {
-
-    protected $wellKnownUri = '/.well-known/oauth-authorization-server';
-
     /**
      * Get the defined well-known URI.  This is the URI
      * that is concatenated to the issuer URL.
      *
      * @return string
      */
-    public function getWellKnownUri(): string
+    public function getWellKnown(): string
     {
-        return $this->wellKnownUri;
+        return '/.well-known/oauth-authorization-server';
     }
-
 }

--- a/src/Discovery/Oauth.php
+++ b/src/Discovery/Oauth.php
@@ -17,14 +17,8 @@
 
 namespace Okta\JwtVerifier\Discovery;
 
-class Oauth implements DiscoveryMethodInterface
+class Oauth implements DiscoveryMethod
 {
-    /**
-     * Get the defined well-known URI.  This is the URI
-     * that is concatenated to the issuer URL.
-     *
-     * @return string
-     */
     public function getWellKnown(): string
     {
         return '/.well-known/oauth-authorization-server';

--- a/src/Discovery/Oidc.php
+++ b/src/Discovery/Oidc.php
@@ -17,18 +17,10 @@
 
 namespace Okta\JwtVerifier\Discovery;
 
-class Oidc implements DiscoveryMethodInterface
+class Oidc implements DiscoveryMethod
 {
-
-    /**
-     * Get the defined well-known URI.  This is the URI
-     * that is concatenated to the issuer URL.
-     *
-     * @return string
-     */
     public function getWellKnown(): string
     {
         return '/.well-known/openid-configuration';
     }
-
 }

--- a/src/Discovery/Oidc.php
+++ b/src/Discovery/Oidc.php
@@ -17,12 +17,8 @@
 
 namespace Okta\JwtVerifier\Discovery;
 
-use Okta\JwtVerifier\Discovery\DiscoveryMethod as Discovery;
-
-class Oidc extends Discovery
+class Oidc implements DiscoveryMethodInterface
 {
-
-    protected $wellKnownUri = '/.well-known/openid-configuration';
 
     /**
      * Get the defined well-known URI.  This is the URI
@@ -30,9 +26,9 @@ class Oidc extends Discovery
      *
      * @return string
      */
-    public function getWellKnownUri(): string
+    public function getWellKnown(): string
     {
-        return $this->wellKnownUri;
+        return '/.well-known/openid-configuration';
     }
 
 }

--- a/src/Jwt.php
+++ b/src/Jwt.php
@@ -17,8 +17,20 @@
 
 namespace Okta\JwtVerifier;
 
+use Carbon\Carbon;
+
 class Jwt
 {
+    /**
+     * @var string
+     */
+    private $jwt;
+
+    /**
+     * @var array
+     */
+    private $claims;
+
     public function __construct(
         string $jwt,
         array $claims
@@ -28,44 +40,48 @@ class Jwt
         $this->claims = $claims;
     }
 
-    public function getJwt()
+    public function getJwt(): string
     {
         return $this->jwt;
     }
 
-    public function getClaims()
+    public function getClaims(): array
     {
         return $this->claims;
     }
 
+    /**
+     * @param bool $carbonInstance
+     * @return Carbon|int
+     */
     public function getExpirationTime($carbonInstance = true)
     {
+        /** @var int $ts */
         $ts = $this->toJson()->exp;
-        if(class_exists(\Carbon\Carbon::class) && $carbonInstance) {
-            return \Carbon\Carbon::createFromTimestampUTC($ts);
+        if ($carbonInstance && class_exists(Carbon::class)) {
+            return Carbon::createFromTimestampUTC($ts);
         }
 
         return $ts;
     }
 
+    /**
+     * @param bool $carbonInstance
+     * @return Carbon|int
+     */
     public function getIssuedAt($carbonInstance = true)
     {
+        /** @var int $ts */
         $ts = $this->toJson()->iat;
-        if(class_exists(\Carbon\Carbon::class) && $carbonInstance) {
-            return \Carbon\Carbon::createFromTimestampUTC($ts);
+        if ($carbonInstance && class_exists(Carbon::class)) {
+            return Carbon::createFromTimestampUTC($ts);
         }
 
         return $ts;
     }
 
-    public function toJson()
+    public function toJson(): object
     {
-        if(is_resource($this->claims)) {
-            throw new \InvalidArgumentException('Could not convert to JSON');
-        }
-
         return json_decode(json_encode($this->claims));
-
     }
-
 }

--- a/src/JwtVerifier.php
+++ b/src/JwtVerifier.php
@@ -24,7 +24,7 @@ use Http\Discovery\MessageFactoryDiscovery;
 use Http\Discovery\UriFactoryDiscovery;
 use Okta\JwtVerifier\Adaptors\Adaptor;
 use Okta\JwtVerifier\Adaptors\AutoDiscover;
-use Okta\JwtVerifier\Discovery\DiscoveryMethod;
+use Okta\JwtVerifier\Discovery\DiscoveryMethodInterface;
 use Okta\JwtVerifier\Discovery\Oauth;
 
 class JwtVerifier
@@ -35,7 +35,7 @@ class JwtVerifier
     protected $issuer;
 
     /**
-     * @var DiscoveryMethod
+     * @var DiscoveryMethodInterface
      */
     protected $discovery;
 
@@ -61,7 +61,7 @@ class JwtVerifier
 
     public function __construct(
         string $issuer,
-        DiscoveryMethod $discovery = null,
+        DiscoveryMethodInterface $discovery = null,
         Adaptor $adaptor = null,
         Request $request = null,
         int $leeway = 120,
@@ -72,8 +72,9 @@ class JwtVerifier
         $this->adaptor = $adaptor ?: AutoDiscover::getAdaptor();
         $request = $request ?: new Request;
         $this->wellknown = $this->issuer.$this->discovery->getWellKnown();
-        $this->metaData = json_decode($request->setUrl($this->wellknown)->get()
-            ->getBody());
+        $this->metaData = json_decode(
+            $request->setUrl($this->wellknown)->get()->getBody()
+        );
 
         $this->claimsToValidate = $claimsToValidate;
     }

--- a/src/JwtVerifierBuilder.php
+++ b/src/JwtVerifierBuilder.php
@@ -17,9 +17,8 @@
 
 namespace Okta\JwtVerifier;
 
-use Okta\JwtVerifier\Discovery\Oauth;
+use Okta\JwtVerifier\Discovery\DiscoveryMethodInterface;
 use Okta\JwtVerifier\Adaptors\Adaptor;
-use Okta\JwtVerifier\Discovery\DiscoveryMethod;
 use Bretterer\IsoDurationConverter\DurationParser;
 
 class JwtVerifierBuilder
@@ -54,10 +53,10 @@ class JwtVerifierBuilder
     /**
      * Set the Discovery class. This class should be an instance of DiscoveryMethod.
      *
-     * @param DiscoveryMethod $discoveryMethod The DiscoveryMethod instance.
+     * @param DiscoveryMethodInterface $discoveryMethod The DiscoveryMethod instance.
      * @return JwtVerifierBuilder
      */
-    public function setDiscovery(DiscoveryMethod $discoveryMethod): self
+    public function setDiscovery(DiscoveryMethodInterface $discoveryMethod): self
     {
         $this->discovery = $discoveryMethod;
 

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 /******************************************************************************
  * Copyright 2017 Okta, Inc.                                                  *
  *                                                                            *
@@ -15,6 +16,7 @@
  * limitations under the License.                                             *
  ******************************************************************************/
 
+use Psr\Http\Message\ResponseInterface;
 use PHPUnit\Framework\TestCase;
 
 class BaseTestCase extends TestCase
@@ -28,6 +30,6 @@ class BaseTestCase extends TestCase
     {
         parent::setUp();
 
-        $this->response = self::createMock('Psr\Http\Message\ResponseInterface');
+        $this->response = $this->createMock(ResponseInterface::class);
     }
 }

--- a/tests/Unit/Discovery/DefaultDiscoveryMethodTest.php
+++ b/tests/Unit/Discovery/DefaultDiscoveryMethodTest.php
@@ -16,16 +16,16 @@
  * limitations under the License.                                             *
  ******************************************************************************/
 
-use Okta\JwtVerifier\Discovery\DiscoveryMethod;
+use Okta\JwtVerifier\Discovery\DefaultDiscoveryMethod;
 
-class DiscoveryMethodTest extends BaseTestCase
+class DefaultDiscoveryMethodTest extends BaseTestCase
 {
     /** @test */
-    public function sets_well_known_correctly()
+    public function sets_well_known_correctly(): void
     {
-        $oauth = new DiscoveryMethod('test');
+        $oauth = new DefaultDiscoveryMethod('test');
 
-        $this->assertEquals(
+        self::assertEquals(
             'test',
             $oauth->getWellKnown(),
             '.well-known endpoint is not set correctly'

--- a/tests/Unit/Discovery/DiscoveryMethodTest.php
+++ b/tests/Unit/Discovery/DiscoveryMethodTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /******************************************************************************
  * Copyright 2017 Okta, Inc.                                                  *
  *                                                                            *
@@ -15,20 +16,20 @@
  * limitations under the License.                                             *
  ******************************************************************************/
 
-namespace Okta\JwtVerifier\Discovery;
+use Okta\JwtVerifier\Discovery\DiscoveryMethod;
 
-
-class DiscoveryMethod implements DiscoveryMethodInterface
+class DiscoveryMethodTest extends BaseTestCase
 {
-    protected $wellKnown;
-
-    public function __construct(string $wellKnown)
+    /** @test */
+    public function sets_well_known_correctly()
     {
-        $this->wellKnown = $wellKnown;
+        $oauth = new DiscoveryMethod('test');
+
+        $this->assertEquals(
+            'test',
+            $oauth->getWellKnown(),
+            '.well-known endpoint is not set correctly'
+        );
     }
 
-    public function getWellKnown(): string
-    {
-        return $this->wellKnown;
-    }
 }

--- a/tests/Unit/Discovery/OauthTest.php
+++ b/tests/Unit/Discovery/OauthTest.php
@@ -26,7 +26,7 @@ class OauthTest extends BaseTestCase
 
         $this->assertEquals(
             '/.well-known/oauth-authorization-server',
-            $oauth->getWellKnownUri(),
+            $oauth->getWellKnown(),
             '.well-known endpoint is not set correctly'
         );
     }

--- a/tests/Unit/Discovery/OidcTest.php
+++ b/tests/Unit/Discovery/OidcTest.php
@@ -15,20 +15,20 @@
  * limitations under the License.                                             *
  ******************************************************************************/
 
-namespace Okta\JwtVerifier\Discovery;
+use Okta\JwtVerifier\Discovery\Oidc;
 
-
-class DiscoveryMethod implements DiscoveryMethodInterface
+class OidcTest extends BaseTestCase
 {
-    protected $wellKnown;
-
-    public function __construct(string $wellKnown)
+    /** @test */
+    public function sets_well_known_correctly()
     {
-        $this->wellKnown = $wellKnown;
+        $oauth = new Oidc();
+
+        $this->assertEquals(
+            '/.well-known/openid-configuration',
+            $oauth->getWellKnown(),
+            '.well-known endpoint is not set correctly'
+        );
     }
 
-    public function getWellKnown(): string
-    {
-        return $this->wellKnown;
-    }
 }

--- a/tests/Unit/JwtVerifierBuilderTest.php
+++ b/tests/Unit/JwtVerifierBuilderTest.php
@@ -15,15 +15,19 @@
  * limitations under the License.                                             *
  ******************************************************************************/
 
+use Http\Mock\Client;
+use Okta\JwtVerifier\Adaptors\FirebasePhpJwt;
+use Okta\JwtVerifier\JwtVerifier;
 use Okta\JwtVerifier\JwtVerifierBuilder;
+use Okta\JwtVerifier\Request;
 
 class JwtVerifierBuilderTest extends BaseTestCase
 {
     /** @test */
-    public function when_setting_issuer_self_is_returned()
+    public function when_setting_issuer_self_is_returned(): void
     {
         $verifier = new JwtVerifierBuilder();
-        $this->assertInstanceOf(
+        self::assertInstanceOf(
             JwtVerifierBuilder::class,
             $verifier->setIssuer('https://my.issuer.com'),
             'Setting the issuer does not return self.'
@@ -31,10 +35,10 @@ class JwtVerifierBuilderTest extends BaseTestCase
     }
 
     /** @test */
-    public function when_setting_discovery_self_is_returned()
+    public function when_setting_discovery_self_is_returned(): void
     {
         $verifier = new JwtVerifierBuilder();
-        $this->assertInstanceOf(
+        self::assertInstanceOf(
             JwtVerifierBuilder::class,
             $verifier->setDiscovery(new \Okta\JwtVerifier\Discovery\Oauth()),
             'Settings discovery does not return self.'
@@ -42,30 +46,30 @@ class JwtVerifierBuilderTest extends BaseTestCase
     }
 
     /** @test */
-    public function building_the_jwt_verifier_throws_exception_if_issuer_not_set()
+    public function building_the_jwt_verifier_throws_exception_if_issuer_not_set(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $verifier = new JwtVerifierBuilder();
         $verifier->build();
     }
 
     /** @test */
-    public function discovery_defaults_to_oauth_when_building()
+    public function discovery_defaults_to_oauth_when_building(): void
     {
         $this->response
             ->method('getBody')
             ->willreturn('{"issuer": "https://example.com"}');
 
 
-        $httpClient = new \Http\Mock\Client;
+        $httpClient = new Client;
         $httpClient->addResponse($this->response);
-        $request = new \Okta\JwtVerifier\Request($httpClient);
+        $request = new Request($httpClient);
 
         $verifier = new JwtVerifierBuilder($request);
         $verifier = $verifier->setIssuer('https://my.issuer.com')->setClientId("abc123")
-            ->setAdaptor(new \Okta\JwtVerifier\Adaptors\FirebasePhpJwt())->build();
+            ->setAdaptor(new FirebasePhpJwt())->build();
 
-        $this->assertInstanceOf(
+        self::assertInstanceOf(
             \Okta\JwtVerifier\Discovery\Oauth::class,
             $verifier->getDiscovery(),
             'The builder is not defaulting to oauth2 discovery'
@@ -73,23 +77,23 @@ class JwtVerifierBuilderTest extends BaseTestCase
     }
 
     /** @test */
-    public function building_the_verifier_returns_instance_of_jwt_verifier()
+    public function building_the_verifier_returns_instance_of_jwt_verifier(): void
     {
         $this->response
             ->method('getBody')
             ->willreturn('{"issuer": "https://example.com"}');
 
 
-        $httpClient = new \Http\Mock\Client;
+        $httpClient = new Client;
         $httpClient->addResponse($this->response);
-        $request = new \Okta\JwtVerifier\Request($httpClient);
+        $request = new Request($httpClient);
 
         $verifier = new JwtVerifierBuilder($request);
         $verifier = $verifier->setIssuer('https://my.issuer.com')->setClientId("abc123")
-            ->setAdaptor(new \Okta\JwtVerifier\Adaptors\FirebasePhpJwt())->build();
+            ->setAdaptor(new FirebasePhpJwt())->build();
 
-        $this->assertInstanceOf(
-            \Okta\JwtVerifier\JwtVerifier::class,
+        self::assertInstanceOf(
+            JwtVerifier::class,
             $verifier,
             'The verifier builder is not returning an instance of JwtVerifier'
         );

--- a/tests/Unit/JwtVerifierTest.php
+++ b/tests/Unit/JwtVerifierTest.php
@@ -15,31 +15,33 @@
  * limitations under the License.                                             *
  ******************************************************************************/
 
+use Http\Mock\Client;
+use Okta\JwtVerifier\Adaptors\FirebasePhpJwt;
+use Okta\JwtVerifier\Discovery\Oauth;
 use Okta\JwtVerifier\JwtVerifier;
-use PHPUnit\Framework\TestCase;
+use Okta\JwtVerifier\Request;
 
 class JwtVerifierTest extends BaseTestCase
 {
     /** @test */
-    public function can_get_issuer_off_object()
+    public function can_get_issuer_off_object(): void
     {
         $this->response
             ->method('getBody')
             ->willreturn('{"issuer": "https://example.com"}');
 
-
-        $httpClient = new \Http\Mock\Client;
+        $httpClient = new Client;
         $httpClient->addResponse($this->response);
-        $request = new \Okta\JwtVerifier\Request($httpClient);
+        $request = new Request($httpClient);
 
         $verifier = new JwtVerifier(
             'https://my.issuer.com',
-            new \Okta\JwtVerifier\Discovery\Oauth(),
-            new \Okta\JwtVerifier\Adaptors\FirebasePhpJwt(),
+            new Oauth(),
+            new FirebasePhpJwt(),
             $request
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             'https://my.issuer.com',
             $verifier->getIssuer(),
             'Does not return issuer correctly'
@@ -47,55 +49,53 @@ class JwtVerifierTest extends BaseTestCase
     }
 
     /** @test */
-    public function can_get_discovery_off_object()
+    public function can_get_discovery_off_object(): void
     {
         $this->response
             ->method('getBody')
             ->willreturn('{"issuer": "https://example.com"}');
 
-
-        $httpClient = new \Http\Mock\Client;
+        $httpClient = new Client;
         $httpClient->addResponse($this->response);
-        $request = new \Okta\JwtVerifier\Request($httpClient);
+        $request = new Request($httpClient);
 
         $verifier = new JwtVerifier(
             'https://my.issuer.com',
-            new \Okta\JwtVerifier\Discovery\Oauth(),
-            new \Okta\JwtVerifier\Adaptors\FirebasePhpJwt(),
+            new Oauth(),
+            new FirebasePhpJwt(),
             $request
         );
 
-        $this->assertInstanceOf(
-            \Okta\JwtVerifier\Discovery\Oauth::class,
+        self::assertInstanceOf(
+            Oauth::class,
             $verifier->getDiscovery(),
             'Does not return discovery correctly'
         );
     }
 
     /** @test */
-    public function will_get_meta_data_when_verifier_is_constructed()
+    public function will_get_meta_data_when_verifier_is_constructed(): void
     {
         $this->response
             ->method('getBody')
-            ->willreturn('{"issuer": "https://example.com"}');
+            ->willreturn('{"jwks_uri": "https://example.com"}');
 
-
-        $httpClient = new \Http\Mock\Client;
+        $httpClient = new Client;
         $httpClient->addResponse($this->response);
-        $request = new \Okta\JwtVerifier\Request($httpClient);
+        $request = new Request($httpClient);
 
         $verifier = new JwtVerifier(
             'https://my.issuer.com',
-            new \Okta\JwtVerifier\Discovery\Oauth(),
-            new \Okta\JwtVerifier\Adaptors\FirebasePhpJwt(),
+            new Oauth(),
+            new FirebasePhpJwt(),
             $request
         );
 
         $metaData = $verifier->getMetaData();
 
-        $this->assertEquals(
+        self::assertEquals(
             'https://example.com',
-            $metaData->issuer,
+            $metaData->jwks_uri,
             'Metadata was not accessed.'
         );
 

--- a/tests/Unit/RequestTest.php
+++ b/tests/Unit/RequestTest.php
@@ -15,18 +15,18 @@
  * limitations under the License.                                             *
  ******************************************************************************/
 
+use Http\Mock\Client;
 use Okta\JwtVerifier\Request;
-use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
 
 class RequestTest extends BaseTestCase
 {
     /** @test */
-    public function makes_request_to_correct_location()
+    public function makes_request_to_correct_location(): void
     {
-
         $this->response->method('getStatusCode')->willReturn(200);
 
-        $httpClient = new \Http\Mock\Client;
+        $httpClient = new Client;
         $httpClient->addResponse($this->response);
 
         $request = new Request($httpClient);
@@ -34,13 +34,13 @@ class RequestTest extends BaseTestCase
         $response = $request->setUrl('http://example.com')->get();
         $requests = $httpClient->getRequests();
 
-        $this->assertInstanceOf(
-            \Psr\Http\Message\ResponseInterface::class,
+        self::assertInstanceOf(
+            ResponseInterface::class,
             $response,
             'Response was not an instance of ResponseInterface.'
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             'http://example.com',
             $requests[0]->getUri(),
             'Did not make a request to the set URL'
@@ -49,16 +49,16 @@ class RequestTest extends BaseTestCase
     }
 
     /** @test */
-    public function makes_request_to_correct_location_with_query()
+    public function makes_request_to_correct_location_with_query(): void
     {
         $this->response->method('getStatusCode')->willReturn(200);
 
-        $httpClient = new \Http\Mock\Client;
+        $httpClient = new Client;
         $httpClient->addResponse($this->response);
 
         $request = new Request($httpClient);
 
-        $response = $request
+        $request
             ->setUrl('http://example.com')
             ->withQuery('some','query')
             ->withQuery('and','another')
@@ -66,13 +66,7 @@ class RequestTest extends BaseTestCase
 
         $requests = $httpClient->getRequests();
 
-        $this->assertInstanceOf(
-            \Psr\Http\Message\ResponseInterface::class,
-            $response,
-            'Response was not an instance of ResponseInterface.'
-        );
-
-        $this->assertEquals(
+        self::assertEquals(
             'http://example.com?some=query&and=another',
             $requests[0]->getUri(),
             'Did not make a request to the set URL'


### PR DESCRIPTION
Build on https://github.com/okta/okta-jwt-verifier-php/pull/61 and adds some additional improvements. Separated in a new PR because they are not all BC (if people have extended classes they must also add the new type info).

- added type info where possible, added docblocks where possible 
- consistent spaces in `if` and `foreach`
- renamed `DiscoveryMethodInterface` to `DiscoveryMethod` analog to how `Adaptor` is set up
- added docker file to run tests locally, added info in README