### PR TITLE
Adding cache driver and deprecating metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,19 @@ $jwtVerifier = (new \Okta\JwtVerifier\JwtVerifierBuilder())
     ->build();
 ```
 
+### Caching
+It's strongly suggested to cache the keys to improve performance. You can pass an implementation of `\Psr\SimpleCache\CacheInterface`
+to the Adaptor constructor.
+
+For example, in laravel:
+```php
+// note: named parameters are only valid for php >= 8.0
+->setAdaptor(new \Okta\JwtVerifier\Adaptors\FirebasePhpJwt(request: null, leeway: 120, cache: app('cache')->store()))
+```
+
+If using symphony, you may need to use an adaptor:
+https://symfony.com/doc/current/components/cache/psr6_psr16_adapters.html
+
 ## Validating an Access Token
 
 After you have a `$jwtVerifier` from the above section and an `access_token` from a successful sign in, or

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,9 @@
         "php-http/message": "^1.8",
         "php-http/discovery": "^1.9",
         "php-http/curl-client": "^2.1",
-        "bretterer/iso_duration_converter": "^0.1.0"
+        "bretterer/iso_duration_converter": "^0.1.0",
+        "ext-json": "*",
+        "illuminate/cache": "^8.83.1 || ^9.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0 ",
@@ -31,6 +33,7 @@
         "squizlabs/php_codesniffer": "^3.5",
         "php-http/mock-client": "^1.4",
         "guzzlehttp/psr7": "~2.0.0",
-        "firebase/php-jwt": "^5.2"
+        "firebase/php-jwt": "^5.2",
+        "mockery/mockery": "^1.5"
     }
 }

--- a/src/Adaptors/Adaptor.php
+++ b/src/Adaptors/Adaptor.php
@@ -21,7 +21,7 @@ use Okta\JwtVerifier\Jwt;
 
 interface Adaptor
 {
-    public function getKeys($jku);
+    public function getKeys(string $jku);
     public function decode($jwt, $keys): Jwt;
     public static function isPackageAvailable();
 }


### PR DESCRIPTION
I understand that these seem like drastic changes, but this maintains
existing functionality, while significantly improving performance.

*Removing metadata retrieval in JwtVerifier constructor*

The Okta documentation clearly indicates that the keys endpoint is not
dynamic (see here: https://developer.okta.com/docs/reference/api/oidc/#keys).

Retrieving the metadata every time the model is instantiated is
unnessesary network overhead, process latency, and app complexity.
There really just isn't a good reason for doing so.

In order to preserve backwards compatibility, that request process has
been moved into the `getMeaData()` function, and a `@deprecated` tag
added.

*Adding caching functionality*

Okta's own documentation strongly suggests caching the retrieved keys
(see
https://developer.okta.com/docs/reference/api/oidc/#best-practices).

In an effort to improve upon this, you can now pass an implementation of `\Psr\SimpleCache\CacheInterface`.

The ttl is hardcoded at 24 hours, though okta suggests caching for up to 90 days.

NOTE: If no implemenation is passed, an instance will be created only using an in-memory
store that is only valid for the lifecycle of the request.

*various code cleanup*

- Return types added to modified methods
- unused imports removed
- removed irrelivent checks in validation methods
- bringing in mockery library to facilitate tests
- added missing `ext-json` dependency