### PR TITLE
fix: Firebase/php-jwt compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,11 @@
         "php-http/curl-client": "^2.1",
         "bretterer/iso_duration_converter": "^0.1.0",
         "ext-json": "*",
+<<<<<<< HEAD
         "illuminate/cache": "^8.83.1 || ^9.0",
+=======
+        "illuminate/cache": "^8.83.1 || ^9.0"
+>>>>>>> 9ede060 (Adding cache driver and depricating metadata)
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0 ",

--- a/composer.json
+++ b/composer.json
@@ -24,20 +24,31 @@
         "php-http/discovery": "^1.9",
         "php-http/curl-client": "^2.1",
         "bretterer/iso_duration_converter": "^0.1.0",
+<<<<<<< HEAD
         "ext-json": "*",
 <<<<<<< HEAD
         "illuminate/cache": "^8.83.1 || ^9.0",
 =======
         "illuminate/cache": "^8.83.1 || ^9.0"
+<<<<<<< HEAD
 >>>>>>> 9ede060 (Adding cache driver and depricating metadata)
+=======
+=======
+        "firebase/php-jwt": "^6.0"
+>>>>>>> 83899c7 (fix: Firebase/php-jwt compatibility)
+>>>>>>> 79d2bbc (fix: Firebase/php-jwt compatibility)
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0 ",
         "symfony/var-dumper": "^5.1",
         "squizlabs/php_codesniffer": "^3.5",
         "php-http/mock-client": "^1.4",
+<<<<<<< HEAD
         "guzzlehttp/psr7": "~2.0.0",
         "firebase/php-jwt": "^5.2",
         "mockery/mockery": "^1.5"
+=======
+        "guzzlehttp/psr7": "~2.0.0"
+>>>>>>> 83899c7 (fix: Firebase/php-jwt compatibility)
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "php-http/curl-client": "^2.1",
         "bretterer/iso_duration_converter": "^0.1.0",
         "ext-json": "*",
-        "illuminate/cache": "^8.83.1 || ^9.0"
+        "illuminate/cache": "^8.83.1 || ^9.0",
+        "firebase/php-jwt": "^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0 ",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
         "bretterer/iso_duration_converter": "^0.1.0",
         "ext-json": "*",
         "illuminate/cache": "^8.83.1 || ^9.0",
-        "firebase/php-jwt": "^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0 ",

--- a/composer.json
+++ b/composer.json
@@ -25,22 +25,7 @@
         "php-http/curl-client": "^2.1",
         "bretterer/iso_duration_converter": "^0.1.0",
         "ext-json": "*",
-<<<<<<< HEAD
-<<<<<<< HEAD
-        "illuminate/cache": "^8.83.1 || ^9.0",
-=======
         "illuminate/cache": "^8.83.1 || ^9.0"
-<<<<<<< HEAD
->>>>>>> 9ede060 (Adding cache driver and depricating metadata)
-=======
-=======
-        "firebase/php-jwt": "^6.0"
->>>>>>> 83899c7 (fix: Firebase/php-jwt compatibility)
->>>>>>> 79d2bbc (fix: Firebase/php-jwt compatibility)
-=======
-        "illuminate/cache": "^8.83.1 || ^9.0",
-        "firebase/php-jwt": "^6.0"
->>>>>>> eb2898a (feat: remove require firebase/php-jwt)
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0 ",

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
         "php-http/discovery": "^1.9",
         "php-http/curl-client": "^2.1",
         "bretterer/iso_duration_converter": "^0.1.0",
-<<<<<<< HEAD
         "ext-json": "*",
+<<<<<<< HEAD
 <<<<<<< HEAD
         "illuminate/cache": "^8.83.1 || ^9.0",
 =======
@@ -37,18 +37,18 @@
         "firebase/php-jwt": "^6.0"
 >>>>>>> 83899c7 (fix: Firebase/php-jwt compatibility)
 >>>>>>> 79d2bbc (fix: Firebase/php-jwt compatibility)
+=======
+        "illuminate/cache": "^8.83.1 || ^9.0",
+        "firebase/php-jwt": "^6.0"
+>>>>>>> eb2898a (feat: remove require firebase/php-jwt)
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0 ",
         "symfony/var-dumper": "^5.1",
         "squizlabs/php_codesniffer": "^3.5",
         "php-http/mock-client": "^1.4",
-<<<<<<< HEAD
         "guzzlehttp/psr7": "~2.0.0",
         "firebase/php-jwt": "^5.2",
         "mockery/mockery": "^1.5"
-=======
-        "guzzlehttp/psr7": "~2.0.0"
->>>>>>> 83899c7 (fix: Firebase/php-jwt compatibility)
     }
 }

--- a/src/Adaptors/FirebasePhpJwt.php
+++ b/src/Adaptors/FirebasePhpJwt.php
@@ -22,8 +22,6 @@ use Firebase\JWT\JWT as FirebaseJWT;
 use Illuminate\Cache\ArrayStore;
 use Firebase\JWT\Key;
 use Illuminate\Cache\ArrayStore;
-use Firebase\JWT\Key;
-use Illuminate\Cache\ArrayStore;
 use Okta\JwtVerifier\Jwt;
 use Okta\JwtVerifier\Request;
 use UnexpectedValueException;

--- a/src/Adaptors/FirebasePhpJwt.php
+++ b/src/Adaptors/FirebasePhpJwt.php
@@ -22,6 +22,7 @@ use Firebase\JWT\JWT as FirebaseJWT;
 use Illuminate\Cache\ArrayStore;
 use Firebase\JWT\Key;
 use Illuminate\Cache\ArrayStore;
+use Firebase\JWT\Key;
 use Okta\JwtVerifier\Jwt;
 use Okta\JwtVerifier\Request;
 use UnexpectedValueException;

--- a/src/Adaptors/FirebasePhpJwt.php
+++ b/src/Adaptors/FirebasePhpJwt.php
@@ -21,7 +21,6 @@ use Carbon\Carbon;
 use Firebase\JWT\JWT as FirebaseJWT;
 use Illuminate\Cache\ArrayStore;
 use Firebase\JWT\Key;
-use Illuminate\Cache\ArrayStore;
 use Okta\JwtVerifier\Jwt;
 use Okta\JwtVerifier\Request;
 use UnexpectedValueException;

--- a/src/Adaptors/FirebasePhpJwt.php
+++ b/src/Adaptors/FirebasePhpJwt.php
@@ -20,6 +20,7 @@ namespace Okta\JwtVerifier\Adaptors;
 use Carbon\Carbon;
 use Firebase\JWT\JWT as FirebaseJWT;
 use Illuminate\Cache\ArrayStore;
+use Firebase\JWT\Key;
 use Okta\JwtVerifier\Jwt;
 use Okta\JwtVerifier\Request;
 use UnexpectedValueException;
@@ -71,8 +72,10 @@ class FirebasePhpJwt implements Adaptor
 
     public function decode($jwt, $keys): Jwt
     {
-        FirebaseJWT::$leeway = $this->leeway;
-        $decoded = (array)FirebaseJWT::decode($jwt, $keys, ['RS256']);
+        $keys = array_map(function ($key) {
+            return new Key($key, 'RS256');
+        }, $keys);
+        $decoded = (array)FirebaseJWT::decode($jwt, $keys);
         return (new Jwt($jwt, $decoded));
     }
 

--- a/src/Adaptors/FirebasePhpJwt.php
+++ b/src/Adaptors/FirebasePhpJwt.php
@@ -23,6 +23,7 @@ use Illuminate\Cache\ArrayStore;
 use Firebase\JWT\Key;
 use Illuminate\Cache\ArrayStore;
 use Firebase\JWT\Key;
+use Illuminate\Cache\ArrayStore;
 use Okta\JwtVerifier\Jwt;
 use Okta\JwtVerifier\Request;
 use UnexpectedValueException;

--- a/src/Adaptors/FirebasePhpJwt.php
+++ b/src/Adaptors/FirebasePhpJwt.php
@@ -21,6 +21,7 @@ use Carbon\Carbon;
 use Firebase\JWT\JWT as FirebaseJWT;
 use Illuminate\Cache\ArrayStore;
 use Firebase\JWT\Key;
+use Illuminate\Cache\ArrayStore;
 use Okta\JwtVerifier\Jwt;
 use Okta\JwtVerifier\Request;
 use UnexpectedValueException;


### PR DESCRIPTION
Resolves #94 
Resolves #93 

I understand that these seem like drastic changes, but this maintains
existing functionality, while significantly improving performance.

*Removing metadata retrieval in JwtVerifier constructor*

The Okta documentation clearly indicates that the keys endpoint is not
dynamic (see here: https://developer.okta.com/docs/reference/api/oidc/#keys).

Retrieving the metadata every time the model is instantiated is
unnessesary network overhead, process latency, and app complexity.
There really just isn't a good reason for doing so.

In order to preserve backwards compatibility, that request process has
been moved into the `getMeaData()` function, and a `@deprecated` tag
added.

*Adding caching functionality*

Okta's own documentation strongly su