### PR TITLE
remove nonce check from access token validation

### DIFF
--- a/src/JwtVerifier.php
+++ b/src/JwtVerifier.php
@@ -158,7 +158,6 @@ class JwtVerifier
             case 'access':
                 $this->validateAudience($claims);
                 $this->validateClientId($claims);
-                $this->validateNonce($claims);
                 break;
         }
     }


### PR DESCRIPTION
access tokens don’t have a `nonce` claim so this code was never doing anything