### PR TITLE
make the cache ttl compatible with Symfony

### DIFF
--- a/src/Adaptors/FirebasePhpJwt.php
+++ b/src/Adaptors/FirebasePhpJwt.php
@@ -67,7 +67,7 @@ class FirebasePhpJwt implements Adaptor
         }
 
         $keys = json_decode($this->request->setUrl($jku)->get()->getBody()->getContents());
-        $this->cache->set($cacheKey, $keys, Carbon::now()->addDay());
+        $this->cache->set($cacheKey, $keys, Carbon::now()->addDay()->diffInRealSeconds());
 
         return self::parseKeySet($keys);
     }


### PR DESCRIPTION
The cache used in the FirebaseJwtAdapter is not compatible with symfony/cache because it uses a Carbon date for the cache item TTL but Symfony only accepts an integer or a DateInterval.

https://github.com/symfony/cache/blob/364fc90734230d936ac2db8e897cc03ec8497bbb/CacheItem.php#L90
```php
    public function expiresAfter($time): self
    {
        if (null === $time) {
            $this->expiry = null;
        } elseif ($time instanceof \DateInterval) {
            $this->expiry = microtime(true) + \DateTime::createFromFormat('U', 0)->add($time)->format('U.u');
        } elseif (\is_int($time)) {
            $this->expiry = $time + microtime(true);
        } else {
            throw new InvalidArgumentException(sprintf('Expiration date must be an integer, a DateInterval or null, "%s" given.', get_debug_type($time)));
        }

        return $this;
    }
```

So we get the following exception when setting the TTL:
```yaml
{
    class: "Symfony\\Component\\Cache\\Exception\\InvalidArgumentException"
    detail: "Expiration date must be an integer, a DateInterval or null, \"Carbon\\Carbon\" given."
}
```

Issue : #107 