### PR TITLE
Obvious Fix Deprecated: Creation of dynamic property

### DIFF
--- a/src/Adaptors/FirebasePhpJwt.php
+++ b/src/Adaptors/FirebasePhpJwt.php
@@ -40,6 +40,11 @@ class FirebasePhpJwt implements Adaptor
      */
     private $leeway;
 
+    /**
+     * @var CacheInterface
+     */
+    private $cache;
+
     public function __construct(Request $request = null, int $leeway = 120, CacheInterface $cache = null)
     {
         $this->request = $request ?: new Request();


### PR DESCRIPTION
Obvious Fix:

Fix the deprecated php 8.2:
`PHP Deprecated:  Creation of dynamic property Okta\JwtVerifier\Adaptors\FirebasePhpJwt::$cache`